### PR TITLE
readme: expanded routing table

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,23 @@ Ask your agent:
 
 ## Which Skill Should I Use?
 
-| Use case | Skill |
-|----------|-------|
-| Ad-hoc terminal queries, MCP integration | **goldrush-cli** |
-| Historical data, batch queries, REST endpoints | **goldrush-foundational-api** |
-| Real-time price feeds, live DEX monitoring, streaming | **goldrush-streaming-api** |
-| Autonomous agents, no API key, pay-per-request | **goldrush-x402** |
+| If the user asks for... | Use this skill | NOT this skill | Why |
+|----------|-----------------|---------------|-----|
+| "Check wallet balance", "get my tokens", "portfolio value" | **goldrush-foundational-api** | CLI, x402 | REST API with `getTokenBalancesForWalletAddress`, supports 100+ chains, returns USD quotes + spam filtering |
+| "Recent transactions", "transaction history", "did I receive X token?" | **goldrush-foundational-api** | Streaming API | Use `getRecentTransactionsForAddress` (v3) or `getTransactionsForAddressV3` (paginated). Streaming is for live push, not history. |
+| "Live price feed", "OHLCV candles", "new DEX pairs", "wallet activity alerts" | **goldrush-streaming-api** | Foundational API | Sub-second GraphQL subscriptions via WebSocket. Chain names: `ETH_MAINNET` (not `eth-mainnet`). All endpoints currently free (Beta). |
+| "I don't have an API key", "pay per request", "autonomous agent with wallet" | **goldrush-x402** | Foundational API | x402 uses HTTP 402 + stablecoin payments on Base. No signup, no monthly fee. Same endpoints as Foundational API. |
+| "Historical token prices", "portfolio over time", "tax report" | **goldrush-foundational-api** | Streaming API | `getTokenPrices` (historical) and `getHistoricalPortfolioForWalletAddress` — only Foundational API provides historical time-series data. |
+| "Token approvals", "who can spend my tokens", "revoke approval" | **goldrush-foundational-api** | x402, CLI | `getApprovals` endpoint returns spender list + values at risk. Only available via Foundational API. |
+| "Cross-chain balances", "which chains is this address on?" | **goldrush-foundational-api** | Streaming API | `getAddressActivity` (discover chains) + `getMultiChainBalances` (fetch all). Streaming API is single-chain only. |
+
+### Key Decision Rules
+
+1. **Historical vs Real-Time:** If the user says "recent", "history", "past", "tax", "portfolio over time" → Foundational API. If they say "live", "real-time", "stream", "alerts", "OHLCV" → Streaming API.
+2. **With API Key vs Without:** If the user mentions "no signup", "no account", "pay per use", "autonomous agent" → x402. If they have an API key → Foundational API or Streaming API.
+3. **Chain Name Format:** Foundational API and CLI use `eth-mainnet` (kebab-case). Streaming API uses `ETH_MAINNET` (SCREAMING_SNAKE_CASE). x402 uses same format as Foundational API (`eth-mainnet`).
+4. **Beta Status:** All Streaming API endpoints are currently in Beta and free (0 credits). Foundational API and x402 are production-ready.
+5. **Multi-Chain:** Only Foundational API supports cross-chain queries (`getAddressActivity`, `getMultiChainBalances`). Streaming API is single-chain per subscription.
 
 ## Supported Chains
 


### PR DESCRIPTION
## What this adds
Expands the routing table in README.md from 4 generic rows to targeted skill-to-skill comparisons with explicit decision rules.

## Why it matters
Agents had no structured guidance for choosing between foundational-api, streaming-api, x402, and CLI, the most common failure mode is wrong tool selection at the start of a request, which cascades into invalid API calls and wasted credits. This adds the chain name format difference (eth-mainnet vs ETH_MAINNET) and 5 key decision rules that cover the cases the existing 4-row table missed.